### PR TITLE
Implement lazy loaded pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,14 +1,17 @@
+import React, { Suspense, lazy } from "react";
 import { Routes, Route } from "react-router-dom";
-import HomePage from "./pages/HomePage";
-import AboutPage from "./pages/AboutPage";
-import DemoLe from "./pages/DemoLe";
-import ContactPage from "./pages/ContactPage";
-import EnSightsPage from "./pages/EnSightsPage";
-import KAIPage from "./pages/KAIPage";
+import Loading from "./components/Loading";
+
+const HomePage = lazy(() => import("./pages/HomePage"));
+const AboutPage = lazy(() => import("./pages/AboutPage"));
+const DemoLe = lazy(() => import("./pages/DemoLe"));
+const ContactPage = lazy(() => import("./pages/ContactPage"));
+const EnSightsPage = lazy(() => import("./pages/EnSightsPage"));
+const KAIPage = lazy(() => import("./pages/KAIPage"));
 
 const App = () => {
   return (
-    <>
+    <Suspense fallback={<Loading />}>
       <Routes>
         <Route path="/" element={<HomePage />} />
         <Route path="/about" element={<AboutPage />} />
@@ -17,7 +20,7 @@ const App = () => {
         <Route path="/EnSights" element={<EnSightsPage />} />
         <Route path="/KAI" element={<KAIPage />} />
       </Routes>
-    </>
+    </Suspense>
   );
 };
 

--- a/src/components/Loading.jsx
+++ b/src/components/Loading.jsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+const Loading = () => (
+  <div className="flex items-center justify-center min-h-screen text-white">
+    <svg
+      className="animate-spin h-8 w-8 mr-3"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      ></circle>
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8v8z"
+      ></path>
+    </svg>
+    Loading...
+  </div>
+);
+
+export default Loading;


### PR DESCRIPTION
## Summary
- load each page with `React.lazy`
- add a small `Loading` spinner for suspense fallback

## Testing
- `npm run lint` *(fails: 'no-unused-vars' errors)*
- `npm test` *(fails: missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684be35e3d00832dbef32355173ede5e