### PR TITLE
Improve DemoLe mobile layout

### DIFF
--- a/src/components/BetaSection.jsx
+++ b/src/components/BetaSection.jsx
@@ -38,7 +38,7 @@ const BetaSection = () => {
                         whileInView={{ opacity: 1, x: 0 }}
                         viewport={{ once: true }}
                         transition={{ duration: 0.8, delay: 0.2 }}
-                        className="group bg-white/10 backdrop-blur-lg rounded-xl p-6 border border-white/20 hover:border-white/30 transition-all duration-300 relative flex flex-col h-full"
+                        className="group liquid-glass rounded-xl p-6 hover:border-white/30 transition-all duration-300 flex flex-col h-full"
                     >
                         <div className="absolute inset-0 rounded-xl bg-gradient-to-r from-white/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
                         <div className="relative z-10">
@@ -67,7 +67,7 @@ const BetaSection = () => {
                         whileInView={{ opacity: 1, x: 0 }}
                         viewport={{ once: true }}
                         transition={{ duration: 0.8, delay: 0.4 }}
-                        className="group bg-white/10 backdrop-blur-lg rounded-xl p-6 border border-white/20 hover:border-white/30 transition-all duration-300 relative flex flex-col h-full"
+                        className="group liquid-glass rounded-xl p-6 hover:border-white/30 transition-all duration-300 flex flex-col h-full"
                     >
                         <div className="absolute inset-0 rounded-xl bg-gradient-to-r from-white/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
                         <div className="relative z-10">

--- a/src/components/BetaSection.jsx
+++ b/src/components/BetaSection.jsx
@@ -32,13 +32,13 @@ const BetaSection = () => {
                     </motion.div>
                 </div>
 
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-10 items-start">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-10 items-stretch">
                     <motion.div
                         initial={{ opacity: 0, x: -20 }}
                         whileInView={{ opacity: 1, x: 0 }}
                         viewport={{ once: true }}
                         transition={{ duration: 0.8, delay: 0.2 }}
-                        className="group bg-white/5 backdrop-blur-sm rounded-xl p-6 border border-white/10 hover:border-white/30 transition-all duration-300 relative"
+                        className="group bg-white/10 backdrop-blur-lg rounded-xl p-6 border border-white/20 hover:border-white/30 transition-all duration-300 relative flex flex-col h-full"
                     >
                         <div className="absolute inset-0 rounded-xl bg-gradient-to-r from-white/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
                         <div className="relative z-10">
@@ -67,7 +67,7 @@ const BetaSection = () => {
                         whileInView={{ opacity: 1, x: 0 }}
                         viewport={{ once: true }}
                         transition={{ duration: 0.8, delay: 0.4 }}
-                        className="group bg-white/5 backdrop-blur-sm rounded-xl p-6 border border-white/10 hover:border-white/30 transition-all duration-300 relative"
+                        className="group bg-white/10 backdrop-blur-lg rounded-xl p-6 border border-white/20 hover:border-white/30 transition-all duration-300 relative flex flex-col h-full"
                     >
                         <div className="absolute inset-0 rounded-xl bg-gradient-to-r from-white/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
                         <div className="relative z-10">

--- a/src/components/DemoLeFeatures.jsx
+++ b/src/components/DemoLeFeatures.jsx
@@ -62,7 +62,7 @@ const DemoLeFeatures = () => {
                     </p>
                 </motion.div>
 
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 items-stretch">
                     {features.map((feature, index) => (
                         <motion.div
                             key={index}
@@ -70,10 +70,10 @@ const DemoLeFeatures = () => {
                             whileInView={{ opacity: 1, y: 0 }}
                             viewport={{ once: true }}
                             transition={{ duration: 0.5, delay: index * 0.1 }}
-                            className="group relative"
+                            className="group relative h-full"
                         >
                             <div className="absolute -inset-0.5 bg-gradient-to-r from-white/10 to-transparent rounded-2xl blur opacity-0 group-hover:opacity-100 transition duration-1000 group-hover:duration-200" />
-                            <div className="relative bg-black/50 backdrop-blur-sm rounded-2xl p-8 border border-white/10 hover:border-white/20 transition-all duration-300">
+                            <div className="relative bg-black/50 backdrop-blur-lg rounded-2xl p-8 border border-white/20 hover:border-white/30 transition-all duration-300 flex flex-col h-full">
                                 <div className={`w-12 h-12 rounded-xl bg-gradient-to-br ${feature.color} flex items-center justify-center mb-6`}>
                                     <feature.icon className="w-6 h-6 text-white" />
                                 </div>

--- a/src/components/DemoLeFeatures.jsx
+++ b/src/components/DemoLeFeatures.jsx
@@ -73,7 +73,7 @@ const DemoLeFeatures = () => {
                             className="group relative h-full"
                         >
                             <div className="absolute -inset-0.5 bg-gradient-to-r from-white/10 to-transparent rounded-2xl blur opacity-0 group-hover:opacity-100 transition duration-1000 group-hover:duration-200" />
-                            <div className="relative bg-black/50 backdrop-blur-lg rounded-2xl p-8 border border-white/20 hover:border-white/30 transition-all duration-300 flex flex-col h-full">
+                            <div className="relative liquid-glass rounded-2xl p-8 hover:border-white/30 transition-all duration-300 flex flex-col h-full">
                                 <div className={`w-12 h-12 rounded-xl bg-gradient-to-br ${feature.color} flex items-center justify-center mb-6`}>
                                     <feature.icon className="w-6 h-6 text-white" />
                                 </div>

--- a/src/components/DemoLeHero.jsx
+++ b/src/components/DemoLeHero.jsx
@@ -28,9 +28,14 @@ const DemoLeHero = () => {
       <motion.div style={{ y }} className="relative z-10 min-h-screen">
         <div className="grid grid-cols-1 md:grid-cols-2 h-full">
           <div className="order-2 md:order-1 flex items-center justify-center max-w-6xl mx-auto space-y-4 md:pl-[7vw] xl:pl-[10vw] px-4">
-            <h1 className="text-center md:text-left text-3xl lg:text-4xl xl:text-6xl font-semibold text-white/90">
-              Democratizing Legal Assistance
-            </h1>
+            <div className="space-y-2">
+              <h1 className="text-center md:text-left text-3xl lg:text-4xl xl:text-6xl font-semibold text-white/90">
+                Democratizing Legal Assistance
+              </h1>
+              <p className="text-center md:text-left text-lg text-white/70">
+                AI-Powered Legal Assistant
+              </p>
+            </div>
           </div>
           <div className="order-1 md:order-2 h-[80vh] relative">
             <Canvas className="w-full h-full">

--- a/src/components/DemoLeHero.jsx
+++ b/src/components/DemoLeHero.jsx
@@ -1,13 +1,11 @@
 "use client";
-import React, { useState, useEffect, useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import { motion, useScroll, useTransform } from "framer-motion";
 import { Canvas } from "@react-three/fiber";
 import DemoLePhone from "../design/DemoLePhone";
-import PhoneLeft from "../assets/PhoneLeft.png";
 import { Spotlight } from "../design/Spotlight";
 import { StarsBackground } from "../design/StarsBackground";
 import { ShootingStars } from "../design/ShootingStars";
-import { TextGenerateEffect } from "../design/TextGenerateEffect";
 
 const DemoLeHero = () => {
   const containerRef = useRef(null);
@@ -15,77 +13,36 @@ const DemoLeHero = () => {
     target: containerRef,
     offset: ["start start", "end start"],
   });
-  const [words, setWords] = useState("Democratizing Legal Assistance");
-  const [screenWidth, setScreenWidth] = useState(
-    typeof window !== "undefined" ? window.innerWidth : 0,
-  );
-  const isMobile = screenWidth <= 768;
-
   useEffect(() => {
-    const handleResize = () => setScreenWidth(window.innerWidth);
-    window.addEventListener("resize", handleResize);
-    return () => window.removeEventListener("resize", handleResize);
+    // Cleanup just in case we add listeners later
+    return () => {};
   }, []);
-
-  useEffect(() => {
-    return scrollYProgress.onChange((latest) => {
-      if (latest >= 0.2) {
-        setWords("AI-Powered Legal Assistant");
-      } else {
-        setWords("Democratizing Legal Assistance");
-      }
-    });
-  }, [scrollYProgress]);
 
   const y = useTransform(scrollYProgress, [0, 0.5, 1], [0, 0, -100]);
 
   return (
-    <div
-      ref={containerRef}
-      className="w-full min-h-[90vh] relative overflow-hidden"
-    >
+    <div ref={containerRef} className="w-full min-h-screen relative">
       <div className="fixed inset-0 z-0 pointer-events-none">
         <Spotlight />
       </div>
-      <motion.div style={{ y }} className="relative z-10 h-[90vh]">
+      <motion.div style={{ y }} className="relative z-10 min-h-screen">
         <div className="grid grid-cols-1 md:grid-cols-2 h-full">
           <div className="order-2 md:order-1 flex items-center justify-center max-w-6xl mx-auto space-y-4 md:pl-[7vw] xl:pl-[10vw] px-4">
-            {words === "Democratizing Legal Assistance" ? (
-              <h1 className="text-center md:text-left text-3xl lg:text-4xl xl:text-6xl font-semibold text-white/90">
-                {words}
-              </h1>
-            ) : (
-              <TextGenerateEffect
-                key={words}
-                words={words}
-                duration={1}
-                delay={0}
-                filter={!isMobile}
-                className="text-center md:text-left text-3xl lg:text-4xl xl:text-6xl font-semibold text-white/90"
-              />
-            )}
+            <h1 className="text-center md:text-left text-3xl lg:text-4xl xl:text-6xl font-semibold text-white/90">
+              Democratizing Legal Assistance
+            </h1>
           </div>
           <div className="order-1 md:order-2 h-[80vh] relative">
-            {isMobile ? (
-              <img
-                src={PhoneLeft}
-                alt="DemoLe App"
-                className="w-full h-full object-contain"
-              />
-            ) : (
-              <Canvas className="w-full h-full">
-                <DemoLePhone shadows scale={0.9} />
-              </Canvas>
-            )}
+            <Canvas className="w-full h-full">
+              <DemoLePhone shadows scale={0.9} />
+            </Canvas>
           </div>
         </div>
       </motion.div>
-      {!isMobile && (
-        <div className="fixed inset-0 z-0 pointer-events-none">
-          <StarsBackground />
-          <ShootingStars />
-        </div>
-      )}
+      <div className="fixed inset-0 z-0 pointer-events-none">
+        <StarsBackground />
+        <ShootingStars />
+      </div>
     </div>
   );
 };

--- a/src/components/DemoLeHero.jsx
+++ b/src/components/DemoLeHero.jsx
@@ -1,6 +1,6 @@
 "use client";
-import React, { useEffect, useRef } from "react";
-import { motion, useScroll, useTransform } from "framer-motion";
+import React from "react";
+
 import { Canvas } from "@react-three/fiber";
 import DemoLePhone from "../design/DemoLePhone";
 import { Spotlight } from "../design/Spotlight";
@@ -8,24 +8,13 @@ import { StarsBackground } from "../design/StarsBackground";
 import { ShootingStars } from "../design/ShootingStars";
 
 const DemoLeHero = () => {
-  const containerRef = useRef(null);
-  const { scrollYProgress } = useScroll({
-    target: containerRef,
-    offset: ["start start", "end start"],
-  });
-  useEffect(() => {
-    // Cleanup just in case we add listeners later
-    return () => {};
-  }, []);
-
-  const y = useTransform(scrollYProgress, [0, 0.5, 1], [0, 0, -100]);
 
   return (
-    <div ref={containerRef} className="w-full min-h-screen relative">
+    <div className="w-full min-h-screen relative">
       <div className="fixed inset-0 z-0 pointer-events-none">
         <Spotlight />
       </div>
-      <motion.div style={{ y }} className="relative z-10 min-h-screen">
+      <div className="relative z-10 min-h-screen">
         <div className="grid grid-cols-1 md:grid-cols-2 h-full">
           <div className="order-2 md:order-1 flex items-center justify-center max-w-6xl mx-auto space-y-4 md:pl-[7vw] xl:pl-[10vw] px-4">
             <div className="space-y-2">
@@ -43,7 +32,7 @@ const DemoLeHero = () => {
             </Canvas>
           </div>
         </div>
-      </motion.div>
+      </div>
       <div className="fixed inset-0 z-0 pointer-events-none">
         <StarsBackground />
         <ShootingStars />

--- a/src/components/DemoLeProductDescription.jsx
+++ b/src/components/DemoLeProductDescription.jsx
@@ -114,7 +114,7 @@ const DemoLeProductDescription = () => {
                             className="group relative h-full"
                         >
                             <div className="absolute -inset-0.5 bg-gradient-to-r from-white/10 to-transparent rounded-2xl blur opacity-0 group-hover:opacity-100 transition duration-1000 group-hover:duration-200" />
-                            <div className="relative bg-black/50 backdrop-blur-lg rounded-2xl p-8 border border-white/20 hover:border-white/30 transition-all duration-300 flex flex-col h-full">
+                            <div className="relative liquid-glass rounded-2xl p-8 hover:border-white/30 transition-all duration-300 flex flex-col h-full">
                                 <div className={`w-12 h-12 rounded-xl bg-gradient-to-br ${feature.color} flex items-center justify-center mb-6`}>
                                     <feature.icon className="w-6 h-6 text-white" />
                                 </div>

--- a/src/components/DemoLeProductDescription.jsx
+++ b/src/components/DemoLeProductDescription.jsx
@@ -103,7 +103,7 @@ const DemoLeProductDescription = () => {
                     </motion.div>
                 </div>
 
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 items-stretch">
                     {features.map((feature, index) => (
                         <motion.div
                             key={index}
@@ -111,10 +111,10 @@ const DemoLeProductDescription = () => {
                             whileInView={{ opacity: 1, y: 0 }}
                             viewport={{ once: true }}
                             transition={{ duration: 0.5, delay: index * 0.1 }}
-                            className="group relative"
+                            className="group relative h-full"
                         >
                             <div className="absolute -inset-0.5 bg-gradient-to-r from-white/10 to-transparent rounded-2xl blur opacity-0 group-hover:opacity-100 transition duration-1000 group-hover:duration-200" />
-                            <div className="relative bg-black/50 backdrop-blur-sm rounded-2xl p-8 border border-white/10 hover:border-white/20 transition-all duration-300">
+                            <div className="relative bg-black/50 backdrop-blur-lg rounded-2xl p-8 border border-white/20 hover:border-white/30 transition-all duration-300 flex flex-col h-full">
                                 <div className={`w-12 h-12 rounded-xl bg-gradient-to-br ${feature.color} flex items-center justify-center mb-6`}>
                                     <feature.icon className="w-6 h-6 text-white" />
                                 </div>

--- a/src/index.css
+++ b/src/index.css
@@ -105,3 +105,35 @@ p {
   animation: none !important;
   transition: none !important;
 }
+
+/* Liquid glass morphism effect */
+.liquid-glass {
+  position: relative;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  backdrop-filter: blur(20px);
+  overflow: hidden;
+}
+
+.liquid-glass::before {
+  content: "";
+  position: absolute;
+  inset: -40%;
+  background:
+    radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.4), transparent 60%),
+    radial-gradient(circle at 70% 70%, rgba(255, 255, 255, 0.25), transparent 60%);
+  animation: liquidGlass 15s linear infinite;
+  pointer-events: none;
+}
+
+@keyframes liquidGlass {
+  0% {
+    transform: translate(0, 0) rotate(0deg);
+  }
+  50% {
+    transform: translate(10%, 10%) rotate(180deg);
+  }
+  100% {
+    transform: translate(0, 0) rotate(360deg);
+  }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -109,18 +109,13 @@ p {
 /* Liquid glass morphism effect */
 .liquid-glass {
   position: relative;
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  backdrop-filter: blur(20px);
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  backdrop-filter: blur(12px);
   overflow: hidden;
 }
 
+/* remove heavy overlay for cleaner glass look */
 .liquid-glass::before {
-  content: "";
-  position: absolute;
-  inset: -40%;
-  background:
-    radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.4), transparent 60%),
-    radial-gradient(circle at 70% 70%, rgba(255, 255, 255, 0.25), transparent 60%);
-  pointer-events: none;
+  content: none;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -122,18 +122,5 @@ p {
   background:
     radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.4), transparent 60%),
     radial-gradient(circle at 70% 70%, rgba(255, 255, 255, 0.25), transparent 60%);
-  animation: liquidGlass 15s linear infinite;
   pointer-events: none;
-}
-
-@keyframes liquidGlass {
-  0% {
-    transform: translate(0, 0) rotate(0deg);
-  }
-  50% {
-    transform: translate(10%, 10%) rotate(180deg);
-  }
-  100% {
-    transform: translate(0, 0) rotate(360deg);
-  }
 }


### PR DESCRIPTION
## Summary
- update DemoLe hero to always use the canvas phone and remove scroll text animation
- apply glassmorphism look to Beta cards and ensure equal height
- keep product description cards uniform and add blur effect

## Testing
- `npm run lint` *(fails: no-unused-vars in many files)*

------
https://chatgpt.com/codex/tasks/task_e_684c074cb714832db225d1c32779091e