### PR TITLE
Update DemoLe beta announcements

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,7 +23,13 @@ export default [
     rules: {
       ...js.configs.recommended.rules,
       ...reactHooks.configs.recommended.rules,
-      'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
+      'no-unused-vars': [
+        'error',
+        {
+          varsIgnorePattern: '^[A-Z_]|^motion$',
+          argsIgnorePattern: '^[A-Z_]|^motion$'
+        }
+      ],
       'react-refresh/only-export-components': [
         'warn',
         { allowConstantExport: true },

--- a/src/assets/DemoLe-Assets/Iphone16.jsx
+++ b/src/assets/DemoLe-Assets/Iphone16.jsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react'
+import React from 'react'
 import { useGLTF } from '@react-three/drei'
 
 export function Iphone16(props) {

--- a/src/components/BetaSection.jsx
+++ b/src/components/BetaSection.jsx
@@ -28,10 +28,11 @@ const BetaSection = () => {
                             Join Our Beta Program
                         </h2>
                         <p className="text-lg text-white/70 max-w-2xl mx-auto">
-                            Be among the first to experience the future of legal assistance
+                            Be among the first to experience the future of legal assistance.
+                            Our closed beta is underway—reach out for an invite.
                         </p>
                         <p className="text-lg text-white/70 max-w-2xl mx-auto mt-2">
-                            Closed beta is now live. Contact us for access.
+                            Public beta opens on July 15, 2025.
                         </p>
                     </motion.div>
                 </div>

--- a/src/components/BetaSection.jsx
+++ b/src/components/BetaSection.jsx
@@ -3,7 +3,7 @@ import { Calendar, Clock, CheckCircle2, ArrowRight } from "lucide-react";
 import Button from "./Button";
 
 const BetaSection = () => {
-    const releaseDate = new Date("2025-06-15");
+    const releaseDate = new Date("2025-07-15"); // Public beta release
     const today = new Date();
     const daysUntilRelease = Math.ceil((releaseDate - today) / (1000 * 60 * 60 * 24));
 
@@ -30,6 +30,9 @@ const BetaSection = () => {
                         <p className="text-lg text-white/70 max-w-2xl mx-auto">
                             Be among the first to experience the future of legal assistance
                         </p>
+                        <p className="text-lg text-white/70 max-w-2xl mx-auto mt-2">
+                            Closed beta is now live. Contact us for access.
+                        </p>
                     </motion.div>
                 </div>
 
@@ -53,7 +56,7 @@ const BetaSection = () => {
                                     <span className="text-lg text-white/70">days until release</span>
                                 </div>
                                 <div className="text-white/70 space-y-2">
-                                    <p className="text-base">Release Date: June 15, 2025</p>
+                                    <p className="text-base">Release Date: July 15, 2025 (Tentative)</p>
                                     <p className="flex items-center gap-2 text-base">
                                         <Clock className="w-4 h-4" />
                                         <span>12:00 PM IST</span>

--- a/src/components/Stats.jsx
+++ b/src/components/Stats.jsx
@@ -5,8 +5,8 @@ import Button from "./Button";
 const stats = [
     {
         icon: Users,
-        value: "Beta",
-        label: "Testing Upcoming",
+        value: "Closed Beta",
+        label: "Contact us for access",
         description: "Legal professionals using our platform"
     },
     // Commented stats remain available for future use

--- a/src/components/Stats.jsx
+++ b/src/components/Stats.jsx
@@ -5,9 +5,9 @@ import Button from "./Button";
 const stats = [
     {
         icon: Users,
-        value: "Closed Beta",
-        label: "Contact us for access",
-        description: "Legal professionals using our platform"
+        value: "Closed Beta Live",
+        label: "Request an invite",
+        description: "Join our first legal professionals testing DemoLe"
     },
     // Commented stats remain available for future use
 ];

--- a/src/design/InteractiveStarsBackground.jsx
+++ b/src/design/InteractiveStarsBackground.jsx
@@ -3,7 +3,6 @@ import React, { useEffect, useRef, useState } from 'react';
 const InteractiveStarsBackground = () => {
   const canvasRef = useRef(null);
   const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
-  const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
   const starsRef = useRef([]);
   const animationRef = useRef(null);
 
@@ -12,7 +11,6 @@ const InteractiveStarsBackground = () => {
     const ctx = canvas.getContext('2d');
     const updateDimensions = () => {
       const { innerWidth, innerHeight } = window;
-      setDimensions({ width: innerWidth, height: innerHeight });
       canvas.width = innerWidth;
       canvas.height = innerHeight;
     };

--- a/src/design/ParticleCanvas.jsx
+++ b/src/design/ParticleCanvas.jsx
@@ -1,12 +1,12 @@
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useRef, useEffect } from 'react';
 import { Canvas, useFrame, useThree } from '@react-three/fiber';
 import * as THREE from 'three';
 import circleTexture from '../assets/circle.png';
 
 const Stars = () => {
   const group = useRef();
-  const { gl, camera, size } = useThree();
-  const [currentRotation, setCurrentRotation] = useState(new THREE.Vector2());
+  const { gl } = useThree();
+  const currentRotation = useRef(new THREE.Vector2());
   const targetRotation = useRef(new THREE.Vector2());
   const mouse = useRef(new THREE.Vector2()); // Using useRef for persistent mouse coords.
 
@@ -40,19 +40,19 @@ const Stars = () => {
       targetRotation.current.x = mouse.current.y * 0.05;
       targetRotation.current.y = mouse.current.x * 0.05;
 
-      currentRotation.x = THREE.MathUtils.lerp(
-        currentRotation.x,
+      currentRotation.current.x = THREE.MathUtils.lerp(
+        currentRotation.current.x,
         targetRotation.current.x,
         0.1
       );
-      currentRotation.y = THREE.MathUtils.lerp(
-        currentRotation.y,
+      currentRotation.current.y = THREE.MathUtils.lerp(
+        currentRotation.current.y,
         targetRotation.current.y,
         0.1
       );
 
-      group.current.rotation.x = currentRotation.x;
-      group.current.rotation.y = currentRotation.y;
+      group.current.rotation.x = currentRotation.current.x;
+      group.current.rotation.y = currentRotation.current.y;
     }
   });
 

--- a/src/pages/EnSightsPage.jsx
+++ b/src/pages/EnSightsPage.jsx
@@ -112,7 +112,8 @@ const EnSightsPage = () => {
                   We're currently working on bringing EnSights to life. Our team is developing advanced features to help educational institutions make data-driven decisions.
                 </p>
                 <p className="text-gray-300">
-                  Sign up for our newsletter to stay updated on the launch and get early access to beta testing.
+                  Sign up to be notified when our public beta launches on July 15, 2025.
+                  The closed beta is live now—contact us for access.
                 </p>
               </div>
             </motion.div>


### PR DESCRIPTION
## Summary
- adjust DemoLe beta release date to July 15, 2025
- mention closed beta availability and contact info
- update stats to show closed beta status

## Testing
- `npm run lint` *(fails: many unused variable errors)*

------
https://chatgpt.com/codex/tasks/task_e_68519f00c6dc832d8df0223ecc35befc